### PR TITLE
fix: replace afxres.h with winres.h in voidImageViewer.rc

### DIFF
--- a/res/voidImageViewer.rc
+++ b/res/voidImageViewer.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -222,7 +222,7 @@ BEGIN
             VALUE "FileDescription", "voidImageViewer"
             VALUE "FileVersion", "1.0.0.15"
             VALUE "InternalName", "voidImageViewer"
-            VALUE "LegalCopyright", "Copyright © 2026 voidtools"
+            VALUE "LegalCopyright", "Copyright Â© 2026 voidtools"
             VALUE "OriginalFilename", "voidImageViewer.exe"
             VALUE "ProductName", "voidImageViewer"
             VALUE "ProductVersion", "1.0.0.15"


### PR DESCRIPTION
# Fix resource compilation for Visual Studio 2022/2026 compatibility
## Summary

This PR fixes a resource compilation issue that prevents building with newer Visual Studio versions by removing the MFC dependency from the resource script.## hanges Made

### Resource Script Header Fix ([[res/voidImageViewer.rc](https://github.com/voidtools/voidImageViewer/compare/master...hesphoros:voidImageViewer:fix/res/voidImageViewer.rc)](res/voidImageViewer.rc))

- **Changed**: `#include "afxres.h"` → `#include <winres.h>`
- **Why this matters**: 
  - `afxres.h` is part of MFC (Microsoft Foundation Classes) and requires MFC to be installed
  - `winres.h` is a standard Windows SDK header that provides the same resource definitions
  - This project doesn't use MFC, so including `afxres.h` was unnecessary and caused build failures in newer VS versions
  - Eliminates MFC dependency for resource compilation
  - Ensures compatibility with Visual Studio 2022, 2026, and future versions